### PR TITLE
SwingCopyJob's background worker thread (provided via an extended SwingW...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,11 +37,3 @@ nbbuild.xml
 /nbproject/
 /build/
 /out/
-
-# code coverage #
-#################
-cobertura.ser
-
-# other #
-#########
-*.html

--- a/res/resources/DiffReportTemplate.html
+++ b/res/resources/DiffReportTemplate.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+ <head>
+  <title>FileSieve Diff Report</title>
+  <style>
+  	@media (min-width: 1024px) {
+		body {
+			width: 1024px;
+			margin-left: auto;
+			margin-right: auto;
+		}		
+	}
+	body {
+		font-family: sans-serif;
+	}
+	.diffResult {
+		-webkit-border-radius: 10px;
+		-moz-border-radius: 10px;
+		border-radius: 10px;
+		background-color: #ddd;
+		padding: 10px;
+        margin-bottom: 2px;
+	}
+	.fileName {
+		font-size: 150%;
+		font-style: italic;
+		padding-bottom: 10px;
+		border-bottom: 1px solid #aaa;
+	}
+	.matches {
+		-webkit-border-bottom-right-radius: 10px;
+		-webkit-border-bottom-left-radius: 10px;
+		-moz-border-radius-bottomright: 10px;
+		-moz-border-radius-bottomleft: 10px;
+		border-bottom-right-radius: 10px;
+		border-bottom-left-radius: 10px;
+		background-color: #efefef;
+		padding: 10px;
+        padding-bottom: 5px;
+		padding-left: 20px;
+	}
+    .match {
+        margin-bottom: 5px;
+    }
+    .deleted::after {
+		content: "[removed]";
+		font-size: 75%;
+		color: #999;
+		vertical-align:text-top;
+    }
+  </style> 
+ </head>
+ <body>
+  <h1>Duplicate Files</h1>
+  <div class="diffReport">
+   <div class="diffResult">
+    <div class="fileName">
+    </div>
+    <div class="matches">
+     <div class="match">
+     </div>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/src/main/java/FileSieve/BusinessLogic/FileManagement/CopyJobWorkDelegate.java
+++ b/src/main/java/FileSieve/BusinessLogic/FileManagement/CopyJobWorkDelegate.java
@@ -1,0 +1,431 @@
+package FileSieve.BusinessLogic.FileManagement;
+
+import FileSieve.BusinessLogic.FileEnumeration.DiscoveredPath;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Handles the actual work (folder and file copies) for a SwingCopyJob.
+ * This class has package-private access.
+ */
+class CopyJobWorkDelegate implements Runnable {
+
+    private static final int ONE_HUNDRED_PERCENT = 100;
+    private static final int ZERO_PERCENT = 0;
+    private final boolean recursiveCopy;
+    private final CopyWorkResultsReceiver copyWorkDispatcher;
+    private final Set<Path> pathsBeingCopied;
+    private final AtomicBoolean jobCancelled;
+    private final Path destinationFolder;
+    private final Comparator<Path> fileComparator;
+    private final boolean overwriteExistingFiles;
+    private final List<Path> foldersCreatedInTarget = new ArrayList<>();
+    private long totalBytes = 0L;
+    private long copiedBytes = 0L;
+    private int totalPercentCopied = 0;
+    private int copyPathsRecursionLevel = 0;
+
+    protected CopyJobWorkDelegate(CopyWorkResultsReceiver copyWorkDispatcher, Set<Path> pathsBeingCopied, Path destinationFolder, boolean recursiveCopy, boolean overwriteExistingFiles, Comparator<Path> fileComparator) {
+        if (copyWorkDispatcher == null) {
+            throw new IllegalArgumentException("\"copyWorkDispatcher\" parameter cannot be null");
+        }
+        if (pathsBeingCopied == null) {
+            throw new IllegalArgumentException("\"pathsBeingCopied\" parameter cannot be null");
+        }
+        if (destinationFolder == null) {
+            throw new IllegalArgumentException("\"destinationFolder\" parameter cannot be null");
+        }
+        if (fileComparator == null) {
+            throw new IllegalArgumentException("\"fileComparator\" parameter cannot be null");
+        }
+
+        this.copyWorkDispatcher = copyWorkDispatcher;
+        this.pathsBeingCopied = pathsBeingCopied;
+        this.destinationFolder = destinationFolder;
+        this.recursiveCopy = recursiveCopy;
+        this.fileComparator = fileComparator;
+        this.overwriteExistingFiles = overwriteExistingFiles;
+
+        jobCancelled = new AtomicBoolean(false);
+    }
+
+    protected void cancelWork() {
+        jobCancelled.set(true);
+    }
+
+    @Override
+    public void run() {
+        try {
+            for (Path path : pathsBeingCopied) {
+                if (extractPath(path).toFile().exists()) {
+                    retrieveTotalBytes(path);
+                } else {
+                    copyWorkDispatcher.workerException(new IllegalStateException("source pathname does not exist"));
+                }
+            }
+        } catch (SecurityException e) {
+            copyWorkDispatcher.workerException(new SecurityException("SecurityException while calculating bytes to copy", e));
+        } catch (IOException e) {
+            copyWorkDispatcher.workerException(new IOException("IOException while calculating bytes to copy", e));
+        }  catch (Exception e) {
+            copyWorkDispatcher.workerException(new Exception(e.getClass().getSimpleName() + " while calculating bytes to copy", e));
+        }
+
+        try {
+            for (Path path : pathsBeingCopied) {
+                if (!jobCancelled.get()) {
+                    copyPaths(path, destinationFolder);
+                }
+            }
+        } catch (SecurityException e) {
+            copyWorkDispatcher.workerException(new SecurityException("SecurityException while reading or writing files/folders in the source or target", e));
+        } catch (IOException e) {
+            copyWorkDispatcher.workerException(new IOException("IOException while reading or writing files/folders in the source or target", e));
+        } catch (Exception e) {
+            copyWorkDispatcher.workerException(new Exception(e.getClass().getSimpleName() + " while reading or writing files/folders in the source or target", e));
+        }
+
+        copyWorkDispatcher.workCompleted();
+    }
+
+    /**
+     * Utility method called by doInBackground() method to handle file and folder copy operations
+     *
+     * @param sourcePath            folder or file to be copied
+     * @param targetPath            destination folder to which copy is to be created
+     * @throws SecurityException    thrown if the security manager is unable to access a file or folder
+     * @throws IOException          thrown if an IOException occurs during a read or write operation
+     */
+    private void copyPaths(Path sourcePath, Path targetPath) throws SecurityException, IOException {
+        if (!jobCancelled.get()) {
+            if (!sourcePath.equals(destinationFolder)) {
+
+                if (!extractPath(targetPath).toFile().exists()) {
+                    if (!targetPath.toFile().mkdirs()) {
+                        throw new IOException("Unable to create destination folder using File.mkdirs() method");
+                    }
+
+                    if (targetPath.equals(destinationFolder)) {
+                        publishWork(new SimpleImmutableEntry<>(targetPath, ZERO_PERCENT));
+                    }
+                }
+
+                if (Files.isDirectory(extractPath(sourcePath))) {
+                    copyFolder(sourcePath, targetPath);
+
+                } else {
+                    // Create the file's source folder inside the destination folder if provided via a DiscoveredPath instance
+                    if (sourcePath instanceof DiscoveredPath) {
+                        Path sourceFolder = ((DiscoveredPath)sourcePath).getSourceFolder();
+
+                        if (!sourceFolder.getFileName().toString().isEmpty()) {
+                            sourceFolder = sourceFolder.getFileName();
+                            Path pathToCreateInTargetFolder = targetPath.resolve(sourceFolder);
+
+                            if (!foldersCreatedInTarget.contains(sourceFolder)) {
+                                if (!pathToCreateInTargetFolder.toFile().exists()) {
+                                    if (!pathToCreateInTargetFolder.toFile().mkdirs()) {
+                                        throw new IOException("Unable to create \"" + pathToCreateInTargetFolder + "\" folder using File.mkdir() method");
+                                    }
+                                }
+                                foldersCreatedInTarget.add(sourceFolder);
+                            }
+                        }
+                    }
+
+                        /* Determine if the file's parent folder was previously created within the target folder,
+                           searching the "foldersCreateInTarget" list in reverse order */
+                    Path parentPathCreatedInTargetFolder = null;
+                    for (int i = foldersCreatedInTarget.size() - 1; i >= 0; --i) {
+                        if (sourcePath.getParent().endsWith(foldersCreatedInTarget.get(i))) {
+                            parentPathCreatedInTargetFolder = foldersCreatedInTarget.get(i);
+                            break;
+                        }
+                    }
+
+                        /* If file's parent was previously created within the target folder then create the file copy
+                           within that parent, else create the file in the root of the target */
+                    if (parentPathCreatedInTargetFolder != null) {
+                        copyFile(sourcePath, targetPath.resolve(parentPathCreatedInTargetFolder));
+                    } else {
+                        copyFile(sourcePath, targetPath);
+                    }
+
+                }
+            }
+        }
+    }
+
+    private void copyFolder(Path sourcePath, Path targetPath) throws SecurityException, IOException {
+        if (recursiveCopy) {
+            List<Path> filePaths = new ArrayList<>(50);
+            try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(extractPath(sourcePath))) {
+                for (Path path : dirStream) {
+                    filePaths.add(path);
+                }
+            }
+
+            for (Path path : filePaths) {
+                if (!jobCancelled.get()) {
+                    if (Files.isDirectory(extractPath(path))) {
+                        Path newTargetPath;
+                        if (copyPathsRecursionLevel == 0) {
+                            newTargetPath = targetPath.resolve(sourcePath.getFileName().resolve(path.getFileName()));
+                        } else {
+                            newTargetPath = targetPath.resolve(path.getFileName());
+                        }
+
+                        if (!extractPath(newTargetPath).toFile().exists()) {
+                            if (!newTargetPath.toFile().mkdirs()) {
+                                throw new IOException("Unable to create \"" + newTargetPath + "\" folder using File.mkdirs()");
+                            }
+                        }
+
+                        publishWork(new SimpleImmutableEntry<>(newTargetPath, ONE_HUNDRED_PERCENT));
+
+                        ++copyPathsRecursionLevel;
+                        try {
+                            copyPaths(path, newTargetPath);
+                        } finally {
+                            --copyPathsRecursionLevel;
+                        }
+
+                    } else if (Files.isRegularFile(extractPath(path), LinkOption.NOFOLLOW_LINKS)) {
+                        if (copyPathsRecursionLevel == 0) {
+                            Path newTargetPath = targetPath.resolve(sourcePath.getFileName());
+
+                            if (!extractPath(newTargetPath).toFile().exists()) {
+                                if (!newTargetPath.toFile().mkdirs()) {
+                                    throw new IOException("Unable to create \"" + newTargetPath + "\" folder using File.mkdir() method");
+                                }
+                            }
+
+                            copyFile(path, newTargetPath);
+                        } else {
+                            copyFile(path, targetPath);
+                        }
+                    }
+                }
+            }
+
+        } else {
+            // Create the folder's source folder inside the destination folder if provided via a DiscoveredPath instance
+            if (sourcePath instanceof DiscoveredPath) {
+                Path sourceFolder = ((DiscoveredPath)sourcePath).getSourceFolder();
+
+                if (!sourceFolder.getFileName().toString().isEmpty()) {
+                    sourceFolder = sourceFolder.getFileName();
+                    Path pathToCreateInTargetFolder = targetPath.resolve(sourceFolder);
+
+                    if (!foldersCreatedInTarget.contains(sourceFolder)) {
+                        if (!pathToCreateInTargetFolder.toFile().exists()) {
+                            if (!pathToCreateInTargetFolder.toFile().mkdirs()) {
+                                throw new IOException("Unable to create \"" + pathToCreateInTargetFolder + "\" folder using File.mkdir() method (boolean false returned)");
+                            }
+                        }
+                        foldersCreatedInTarget.add(sourceFolder);
+                    }
+                }
+            }
+
+                /* Determine if the folder's parent was previously created within the target folder, searching the
+                   "foldersCreateInTarget" list in reverse order */
+            Path pathToCreateInTargetFolder = null;
+            for (int i = foldersCreatedInTarget.size() - 1; i >= 0; --i) {
+                if (sourcePath.getParent().endsWith(foldersCreatedInTarget.get(i))) {
+                    pathToCreateInTargetFolder = foldersCreatedInTarget.get(i).resolve(sourcePath.getFileName());
+                    break;
+                }
+            }
+
+                /* If folder's parent was previously created within the target folder then create the folder within
+                   that parent, else create the folder in the root of the target */
+            if (pathToCreateInTargetFolder != null) {
+                Path newPathToCreate = targetPath.resolve(pathToCreateInTargetFolder);
+                if (!foldersCreatedInTarget.contains(pathToCreateInTargetFolder)) {
+                    if (!extractPath(newPathToCreate).toFile().exists()) {
+                        if (!newPathToCreate.toFile().mkdirs()) {
+                            throw new IOException("Unable to create \"" + newPathToCreate + "\" folder using File.mkdir() method (boolean false returned)");
+                        }
+                    }
+                    foldersCreatedInTarget.add(pathToCreateInTargetFolder);
+                }
+            } else {
+                if (!targetPath.resolve(sourcePath.getFileName()).toFile().exists()) {
+                    if (!targetPath.resolve(sourcePath.getFileName()).toFile().mkdirs()) {
+                        throw new IOException("Unable to create \"" + targetPath.resolve(sourcePath.getFileName()) + "\" folder using File.mkdir() method (boolean false returned)");
+                    }
+                }
+                foldersCreatedInTarget.add(sourcePath.getFileName());
+            }
+        }
+    }
+
+    /**
+     * Private helper method, called by "copyPaths" method, for copying a single file
+     *
+     * @param fileToCopy            file to copy, passed as a Path instance
+     * @param target                folder within which copy is to be placed
+     * @throws SecurityException    thrown if the security manager denies read-access to the original file or
+     *                              write-access to the destination folder
+     * @throws IOException          thrown if an IOException occurs during read/write operations
+     */
+    private void copyFile(Path fileToCopy, Path target) throws SecurityException, IOException {
+        target = target.resolve(fileToCopy.getFileName());
+
+        int previousPercentCopied;
+        long fileBytes = fileToCopy.toFile().length();  // size of file in bytes
+
+        boolean filesAreSimilar = false;
+        if (fileComparator.compare(fileToCopy, target) == 0) {
+            filesAreSimilar = true;
+        }
+
+        if ((!filesAreSimilar) || overwriteExistingFiles)  {
+            long soFar = 0L;    // file bytes copied thus far
+            int sourceByte;
+            int filePercentCopied = ZERO_PERCENT;
+            int pathnameProgress = ZERO_PERCENT;
+
+            try (
+                    BufferedInputStream bis = new BufferedInputStream(new FileInputStream(fileToCopy.toFile()));
+                    BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(target.toFile()))
+            ) {
+                /* Copy file one byte at time. BufferedInputStream and BufferedOutputStream have buffers so
+                   so this isn't as slow as it might at first seem */
+                while (((sourceByte = bis.read()) != -1) && (!jobCancelled.get())) {
+                    bos.write(sourceByte);
+
+                    // Update copy job's overall progress
+                    previousPercentCopied = totalPercentCopied;
+                    totalPercentCopied = (int) (++copiedBytes * ONE_HUNDRED_PERCENT / totalBytes);
+                    if ((totalPercentCopied != previousPercentCopied) && (totalPercentCopied < ONE_HUNDRED_PERCENT)) {
+                        publishWork(new SimpleImmutableEntry<>(destinationFolder, totalPercentCopied));
+                    }
+
+                    /* Update the progress of the individual file copy if progress has incremented by at least 1 percent
+                       and is not yet 100 percent complete */
+                    filePercentCopied = (int) (++soFar * ONE_HUNDRED_PERCENT / fileBytes);
+                    if ((pathnameProgress != filePercentCopied) && (filePercentCopied < ONE_HUNDRED_PERCENT)) {
+                        pathnameProgress = filePercentCopied;
+                        publishWork(new SimpleImmutableEntry<>(target, pathnameProgress));
+                    }
+                }
+
+                // Delete file fragment
+                if (jobCancelled.get() && (filePercentCopied < ONE_HUNDRED_PERCENT)) {
+                    bos.close();
+
+                    if (!target.toFile().delete()) {
+                        throw new IOException("Unable to delete incomplete file fragment \"" + target.toString() + "\" following job cancellation");
+                    }
+
+                    /* Backtrack... set and publish the total job progress as the value had prior to this attempted
+                       file-copy and set+publish the progress for the failed copy to/as 0 percent */
+                    if (soFar >0) {
+                        copiedBytes -= soFar;
+                        publishWork(new SimpleImmutableEntry<>(target, ZERO_PERCENT));
+                    }
+                    previousPercentCopied = totalPercentCopied;
+                    totalPercentCopied = (int) (copiedBytes * ONE_HUNDRED_PERCENT / totalBytes);
+                    if ((totalPercentCopied != previousPercentCopied) && (totalPercentCopied < ONE_HUNDRED_PERCENT)) {
+                        publishWork(new SimpleImmutableEntry<>(destinationFolder, totalPercentCopied));
+                    }
+                } else {
+                    // No need to set "pathnameProgress" variable to 100... publish completion of the file copy and move on
+                    publishWork(new SimpleImmutableEntry<>(target, ONE_HUNDRED_PERCENT));
+                }
+
+            } catch (IOException e) {
+                // Backtrack... set+publish the total job progress to the value had prior to this attempted file
+                // copy and set+publish the progress for the failed copy to/as 0 percent
+                if (soFar > 0) {
+                    copiedBytes -= soFar;
+                    publishWork(new SimpleImmutableEntry<>(target, ZERO_PERCENT));
+                }
+                previousPercentCopied = totalPercentCopied;
+                totalPercentCopied = (int) (copiedBytes * ONE_HUNDRED_PERCENT / totalBytes);
+                if ((totalPercentCopied != previousPercentCopied) && (totalPercentCopied < ONE_HUNDRED_PERCENT)) {
+                    publishWork(new SimpleImmutableEntry<>(destinationFolder, totalPercentCopied));
+                }
+
+                try {
+                    if ((target.toFile().exists()) && ((target.toFile().length() == 0L) || (soFar > 0L))) {
+                        if (!target.toFile().delete()) {
+                            throw new IOException("An IOException occurred while copying file \"" + fileToCopy.toString() + "\". An incomplete copy was left in the destination folder.", e);
+                        }
+                        throw new IOException("An IOException occurred while copying file \"" + fileToCopy.toString() + "\". An incomplete copy was not left in the destination folder.", e);
+                    } else {
+                        throw new IOException("An IOException occurred while copying file \"" + fileToCopy.toString() + "\".", e);
+                    }
+                } catch (IOException ex) {
+                    throw new IOException("An IOException occurred while copying file \"" + fileToCopy.toString() + "\". An incomplete copy may have been left in the destination folder.", ex);
+                }
+            }
+        } else {
+            copiedBytes += fileBytes;
+            previousPercentCopied = totalPercentCopied;
+            totalPercentCopied = (int) (copiedBytes * ONE_HUNDRED_PERCENT / totalBytes);
+            if ((totalPercentCopied != previousPercentCopied) && (totalPercentCopied < ONE_HUNDRED_PERCENT)) {
+                publishWork(new SimpleImmutableEntry<>(destinationFolder, totalPercentCopied));
+            }
+        }
+    }
+
+    /**
+     * Extracts the decorated (wrapped) Path from a DiscoveredPath instance.
+     *
+     * @param path  a Path instance
+     * @return      the Path decorated by a DiscoveredPath instance, or the same Path as that provided
+     */
+    private static Path extractPath(Path path) {
+        if (path instanceof DiscoveredPath) {
+            return ((DiscoveredPath) path).getPath();
+        } else {
+            return path;
+        }
+    }
+
+    /**
+     * Send work result to the registered CopyWorkDispatcher
+     *
+     * @param result    result to provide
+     */
+    private void publishWork(SimpleImmutableEntry<Path, Integer> result) {
+        copyWorkDispatcher.receiveWorkResults(result);
+    }
+
+    private void retrieveTotalBytes(Path sourcePathname) throws SecurityException, IOException {
+        if (Files.isDirectory(extractPath(sourcePathname))) {
+            try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(extractPath(sourcePathname))) {
+                for (Path path : dirStream) {
+                    if (!jobCancelled.get()) {
+                        // Exclude target folder if it is a subfolder of the source folder
+                        if (Files.isDirectory(extractPath(path), LinkOption.NOFOLLOW_LINKS) && (!path.equals(destinationFolder) && recursiveCopy)) {
+                            retrieveTotalBytes(path);
+                        } else if (Files.isRegularFile(extractPath(path), LinkOption.NOFOLLOW_LINKS)) {
+                            totalBytes += path.toFile().length();
+                        }
+                    }
+                }
+            }
+        } else {
+            totalBytes += sourcePathname.toFile().length();
+        }
+    }
+
+}

--- a/src/main/java/FileSieve/BusinessLogic/FileManagement/CopyWorkResultsReceiver.java
+++ b/src/main/java/FileSieve/BusinessLogic/FileManagement/CopyWorkResultsReceiver.java
@@ -1,0 +1,36 @@
+package FileSieve.BusinessLogic.FileManagement;
+
+import java.nio.file.Path;
+import java.util.AbstractMap.SimpleImmutableEntry;
+
+/**
+ * Defines methods for use by a CopyJobWorkDelegate instance in passing work results and statistics back to a
+ * SwingCopyJob instance. This class has package-private access.
+ */
+interface CopyWorkResultsReceiver {
+
+    /**
+     * Provides a means by which a CopyJobWorkDelegate may convey an exception to a SwingCopyJob's background worker
+     * thread.
+     *
+     * @param exception     any exception thrown which causes the CopyJobWorkDelegate to terminate operations
+     */
+    public void workerException(Exception exception);
+
+    /**
+     * Provides the means by which progress updates may be conveyed by a CopyJobWorkDelegate to a SwingCopyJob.
+     *
+     * @param result    A unit of work representing a progress update for the copy of a specific file, folder, or a
+     *                  progress update for the overall copy job. The update consists of the Path instance representing
+     *                  the item being updating and an Integer representing the percentage of the copy that has been
+     *                  completed.
+     */
+    public void receiveWorkResults(SimpleImmutableEntry<Path, Integer> result);
+
+    /**
+     * Provides a means by which a CopyJobWorkDelegate instance can communicate a "work complete" message to a
+     * SwingCopyJob.
+     */
+    public void workCompleted();
+
+}

--- a/src/main/java/FileSieve/FileSieve.java
+++ b/src/main/java/FileSieve/FileSieve.java
@@ -1,4 +1,3 @@
-
 package FileSieve;
 
 import FileSieve.gui.Controller;
@@ -25,6 +24,9 @@ public class FileSieve {
         });  
     }
 
+    /**
+     * Utility method, for use in troubleshooting only, for printing out items on the classpath
+     */
     private static void printClassPath() {
         ClassLoader cl = ClassLoader.getSystemClassLoader();
         URL[] urls = ((URLClassLoader)cl).getURLs();

--- a/src/main/java/FileSieve/gui/Controller.java
+++ b/src/main/java/FileSieve/gui/Controller.java
@@ -46,7 +46,7 @@ public class Controller {
     private FileEnumerator fileEnumerator;
     private FileDifferentiator fileDifferentiator; 
     static SwingFileManager swingFileManager; //protected so CheckTreeManager could access it (or does it create its own?)
-    private SwingCopyJob swingCopyJob; 
+    protected SwingCopyJob swingCopyJob;
     private DiffReport diffReport;
     List<SimpleImmutableEntry<String, List<File>>> duplicates; //protected so test could mock it
     List<String> deletedPaths; //protected so test could mock it

--- a/src/main/java/FileSieve/gui/ScreenSwitcher.java
+++ b/src/main/java/FileSieve/gui/ScreenSwitcher.java
@@ -55,12 +55,15 @@ public class ScreenSwitcher {
         }
         
         //on window close save window placement preferences
-        mainFrame.setDefaultCloseOperation(javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE);
+        mainFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         mainFrame.addWindowListener(new java.awt.event.WindowAdapter() {
             @Override
             public void windowClosing(java.awt.event.WindowEvent evt) {
                 windowPrefs.save();
-                System.exit(0); 
+
+                if (controller.swingCopyJob != null) {
+                    controller.swingCopyJob.cancelJob();
+                }
             }
         });
         


### PR DESCRIPTION
SwingCopyJob's background worker thread (provided via an extended SwingWorker) now only handles updating of the EDT. It delegates the actual job of copying folders and files to a custom Runnable (CopyJobWorkDelegate class) that is run on its own thread. No perceivable decrease in performance. Next step is to have the CopyJobWorkDelegate manage a ThreadPoolExecutor that oversees a number of threads, one per file to be copied up to some limit, for greater concurrency and to improve performance. Also modified the project's root gitignore file to prevent exclusion of the html DiffReport template and modified the GUI's ScreenSwitcher class to ensure ongoing copy jobs are cancelled prior to exit.
