### PR TITLE
Concurrent file copying

### DIFF
--- a/src/main/java/FileSieve/BusinessLogic/FileManagement/CopyWorkResultsReceiver.java
+++ b/src/main/java/FileSieve/BusinessLogic/FileManagement/CopyWorkResultsReceiver.java
@@ -22,10 +22,10 @@ interface CopyWorkResultsReceiver {
      *
      * @param result    A unit of work representing a progress update for the copy of a specific file, folder, or a
      *                  progress update for the overall copy job. The update consists of the Path instance representing
-     *                  the item being updating and an Integer representing the percentage of the copy that has been
-     *                  completed.
+     *                  the item being updating and a Long representing the percentage of a file that has been copied
+     *                  or the total number of bytes that have been copied by the copy job.
      */
-    public void receiveWorkResults(SimpleImmutableEntry<Path, Integer> result);
+    public void receiveWorkResults(SimpleImmutableEntry<Path, Long> result);
 
     /**
      * Provides a means by which a CopyJobWorkDelegate instance can communicate a "work complete" message to a

--- a/src/main/java/FileSieve/BusinessLogic/FileManagement/FileCopier.java
+++ b/src/main/java/FileSieve/BusinessLogic/FileManagement/FileCopier.java
@@ -56,4 +56,11 @@ interface FileCopier<T, L, C> {
      */
     public void setCopyOperationsListener(L listener);
 
-} // interface FileCopier<T, L>
+    /**
+     * Sets the maximum number of concurrent file copy threads.
+     *
+     * @param fileCopyThreadLimit
+     */
+    public void setFileCopyThreadLimit(int fileCopyThreadLimit);
+
+}

--- a/src/main/java/FileSieve/BusinessLogic/FileManagement/FileManagerFactory.java
+++ b/src/main/java/FileSieve/BusinessLogic/FileManagement/FileManagerFactory.java
@@ -13,13 +13,13 @@ public class FileManagerFactory {
     /**
      * Returns a SwingFileManager instance for handling common file management operations. This implementation of a
      * FileManager returns instances of a SwingCopyJob class for handling folder/file copies. SwingCopyJob
-     * instances use a SwingWorker to handle copy operations.
-     * One worker thread is used per long-running operation (e.g. a file or folder copy).
+     * instances use a SwingWorker to update the EDT.
+     * This parameterless constructor sets the number of threads used for concurrent file copies to 10 per copy job.
      *
      * @return                  a FileManager instance
      */
     public static SwingFileManager getSwingFileManager() {
-        return new SwingWorkerBasedFileManager(1);
+        return new SwingWorkerBasedFileManager(10);
     }
 
-} // class FileManagerFactory
+}

--- a/src/main/java/FileSieve/BusinessLogic/FileManagement/SwingWorkerBasedFileManager.java
+++ b/src/main/java/FileSieve/BusinessLogic/FileManagement/SwingWorkerBasedFileManager.java
@@ -12,16 +12,26 @@ import java.util.Set;
  */
 final class SwingWorkerBasedFileManager extends AbstractFileManager<SwingCopyJob, SwingCopyJobListener, Path> implements SwingFileManager {
 
-    private int workerLimit;
+    private int fileCopyThreadLimit;
     private SwingCopyJobListener swingCopyJobListener;
 
     /**
-     * Future functionality for limiting the number of worker threads used by a copy job.
+     * Constructor for SwingWorkerBasedFileManager class.
      *
-     * @param workerThreadLimit     number of concurrent worker thread (file/folder copies) to be permitted per copy job
+     * @param fileCopyThreadLimit   maximum number of concurrent file copy threads
      */
-    protected SwingWorkerBasedFileManager(int workerThreadLimit) {
-        this.workerLimit = workerThreadLimit;
+    protected SwingWorkerBasedFileManager(int fileCopyThreadLimit) {
+        this.fileCopyThreadLimit = fileCopyThreadLimit;
+    }
+
+    /**
+     * Sets the maximum number of concurrent file copy threads.
+     *
+     * @param fileCopyThreadLimit
+     */
+    @Override
+    public void setFileCopyThreadLimit(int fileCopyThreadLimit) {
+        this.fileCopyThreadLimit = fileCopyThreadLimit;
     }
 
     /**
@@ -54,7 +64,7 @@ final class SwingWorkerBasedFileManager extends AbstractFileManager<SwingCopyJob
             throw new NullPointerException("null path provided for targetPathname parameter");
         }
 
-        return SwingCopyJob.getCopyJob(sourcePathnames, targetPathname, recursionEnabled, overwriteExistingFiles, fileComparator, swingCopyJobListener);
+        return SwingCopyJob.getCopyJob(sourcePathnames, targetPathname, recursionEnabled, overwriteExistingFiles, fileCopyThreadLimit, fileComparator, swingCopyJobListener);
     }
 
     @Override

--- a/src/test/java/FileSieve/BusinessLogic/FileManagement/SwingWorkerBasedFileManagerTest.java
+++ b/src/test/java/FileSieve/BusinessLogic/FileManagement/SwingWorkerBasedFileManagerTest.java
@@ -652,7 +652,9 @@ public class SwingWorkerBasedFileManagerTest implements SwingCopyJobListener {
 
     @Override
     public void JobFinished(SwingCopyJob swingCopyJob, SwingCopyJobException exception) {
-        // System.err.println(throwable.getMessage());
+        if (exception != null) {
+            System.err.println(exception.getClass().getSimpleName() + ": " + exception.getMessage());
+        }
     }
 
     /**

--- a/src/test/java/FileSieve/BusinessLogic/FileManagement/SwingWorkerBasedFileManagerTest.java
+++ b/src/test/java/FileSieve/BusinessLogic/FileManagement/SwingWorkerBasedFileManagerTest.java
@@ -503,15 +503,17 @@ public class SwingWorkerBasedFileManagerTest implements SwingCopyJobListener {
         if (swingCopyJob != null) {
             try {
                 // Let the copy job proceed until at least 2 paths have been copied or 50ms have passed before cancelling it
-                while (pathsCopied <= 1) {
+                while (pathsCopied < 1) {
                     synchronized (lockObject) {
                         lockObject.wait(50);
                     }
                 }
+                //System.err.println("MADE IT THROUGH");
                 Assert.assertTrue("job was successfully issued a cancel request", swingCopyJob.cancelJob());
 
                 // exceptions that occur on internal SwingWorker's background thread are rethrown by this method
                 swingCopyJob.awaitCompletion();
+                //System.err.println("AWAITED");
 
                 int pathsCreated = getChildCount(targetFolder);
                 Assert.assertTrue("cancelling of the recursive copying of a pathname created at least 1 but less than 30 files/folders in the target folder due to job cancellation", (pathsCreated > 1) && (pathsCreated < 30));
@@ -640,7 +642,7 @@ public class SwingWorkerBasedFileManagerTest implements SwingCopyJobListener {
         if (percentProgressed == 100) {
             pathsCopied++;
 
-            if (pathsCopied > 1) {
+            if (pathsCopied >= 1) {
                 synchronized(lockObject) {
                     lockObject.notify();
                 }


### PR DESCRIPTION
Modifications have been made to enable any number of files to be concurrently copied.  Project is compiling, testing, and running well but I'm giving these changes a couple days to simmer.  With my test files (1.5 GB total, 3 of the 184 files of which are very large MOV files and compose 79 percent of the total size), this new version takes 24 seconds compared to the 1 minute 21 seconds to complete the copy job (3.4x improvement in speed for this file set).

SwingCopyJob is currently fixed at 10 file-copy threads but I will add methods to it and FileManager to enable the number of concurrent file-copy threads to be set at job creation or dynamically changed after the job has begun.

The original SwingCopyJob's background worker thread now only handles publishing of progress updates on the EDT.  It delegates copy operations to a Runnable that is started on a separate thread.  That Runnable oversees folder creation in the destination folder and oversees a ThreadPoolExecutor (pool of threads) into which FileCopy tasks are passed (a second Runnable type).

Next major step, after merging of this request, will be to investigate the use of multiple threads per file copy.  It isn't immediately obvious to me how this benefits the overall process.  Perhaps there are advantages to be seen with burst speeds where network connections are involved.  I'll need to go back and run some RichCopy tests first.
